### PR TITLE
Optimize move event emits

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -33,7 +33,6 @@ Game.prototype.emitAll = function() {
  * @param {Player} player - An instance of a player.
  */
 Game.prototype.joinPlayer = function(player) {
-
   // If there are already 2 players, send a join error to the client.
   if (Object.keys(this.players).length >= 2) {
     logger.info(

--- a/src/client/camController.js
+++ b/src/client/camController.js
@@ -19,19 +19,17 @@ var CamController = function(cam, sock, direction) {
   // Register the player for key events.
   var self = this;
   var startMoveEvent = function(keyEvent) {
-    console.log('Key down ' + keyEvent.keyCode);
-    if (socket) {
+    if (self.toggleMovement(keyEvent.keyCode, true) && socket) {
+      console.log('Cam movement started', keyEvent.keyCode);
       socket.emit('move.start', keyEvent.keyCode);
     }
-    self.toggleMovement(keyEvent.keyCode, true);
   };
 
   var endMoveEvent = function(keyEvent) {
-    console.log('Key up ' + keyEvent.keyCode);
-    if (socket) {
+    if (self.toggleMovement(keyEvent.keyCode, false) && socket) {
+      console.log('Cam movement ended', keyEvent.keyCode);
       socket.emit('move.end', keyEvent.keyCode);
     }
-    self.toggleMovement(keyEvent.keyCode, false);
   };
 
   var mouseClickEvent = function() {
@@ -44,25 +42,31 @@ var CamController = function(cam, sock, direction) {
   window.addEventListener('click', mouseClickEvent);
 };
 
-CamController.prototype.toggleMovement = function (keyCode, directionBool) {
+CamController.prototype.toggleMovement = function(keyCode, directionBool) {
+  var hasChanged = false;
   switch (keyCode) {
     case 37:  // Leftarrow
     case 65:  // a key
+      hasChanged = this.left !== directionBool;
       this.left = directionBool;
       break;
     case 38:  // Up arrow
     case 87:  // w key
+      hasChanged = this.forward !== directionBool;
       this.forward = directionBool;
       break;
     case 39:  // Right arrow
     case 68:  // d key
+      hasChanged = this.right !== directionBool;
       this.right = directionBool;
       break;
     case 40:  // Down arrow
     case 83:  // s key
+      hasChanged = this.backward !== directionBool;
       this.backward = directionBool;
       break;
   }
+  return hasChanged;
 };
 
 CamController.prototype.fire = function() {


### PR DESCRIPTION
This PR adds an optimization to the cam controller's move events by not emitting a socket event if the move direction has not changed. For example, the keydown event fires multiple times when the key is held down, causing a lot of unnecessary socket emits and lag.